### PR TITLE
feature: template variable for `AUTHOR_HANDLE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
   To set up the format of your extracted tweet a simple template system is included, found in the Roam Depot plugin settings panel. For each supported `{OPTION}` the variable will be replaced with the extracted tweet information.
 
-  Options available to the template are `{TWEET}`, `{URL}`, `{AUTHOR_NAME}`, `{AUTHOR_URL}`, `{DATE}`, `{NEWLINE}`.  A default temlpate is included.
+  Options available to the template are `{TWEET}`, `{URL}`, `{AUTHOR_NAME}`, `{AUTHOR_HANDLE}`, `{AUTHOR_URL}`, `{DATE}`, `{NEWLINE}`.  A default temlpate is included.
 
   `[[>]] {TWEET} {NEWLINE} [🐦]({URL}) by {AUTHOR_NAME} on [[{DATE}]]`
   

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const panelConfig = {
   settings: [
       {id:     "tweet-template",
        name:   "Tweet Template",
-       description: "variables available are {TWEET}, {URL}, {AUTHOR_NAME}, {AUTHOR_URL}, {DATE}, {NEWLINE} as well as all Roam syntax",
+       description: "variables available are {TWEET}, {URL}, {AUTHOR_NAME}, {AUTHOR_HANDLE}, {AUTHOR_URL}, {DATE}, {NEWLINE} as well as all Roam syntax",
        action: {type:        "input",
                 placeholder: "[[>]] {TWEET} {NEWLINE} [🐦]({URL}) by {AUTHOR_NAME} on [[{DATE}]]",
                 onChange:    (evt) => { 
@@ -85,9 +85,10 @@ async function extractTweet(uid, tweet, template){
       roamDate = window.roamAlphaAPI.util.dateToPageTitle(roamDate)
       var parsedTweet = template.replaceAll('{TWEET}',tweetText);
 
-      // {TWEET}, {URL}, {AUTHOR_NAME}, {AUTHOR_URL}, {DATE}, {NEWLINE}
+      // {TWEET}, {URL}, {AUTHOR_NAME}, {AUTHOR_HANDLE}, {AUTHOR_URL}, {DATE}, {NEWLINE}
       parsedTweet = parsedTweet.replaceAll('{URL}',tweetURL);
       parsedTweet = parsedTweet.replaceAll('{AUTHOR_NAME}',json.author_name);
+      parsedTweet = parsedTweet.replaceAll('{AUTHOR_HANDLE}',json.author_url.split('/').slice(-1));
       parsedTweet = parsedTweet.replaceAll('{AUTHOR_URL}',json.author_url);
       parsedTweet = parsedTweet.replaceAll('{DATE}',roamDate);
       parsedTweet = parsedTweet.replaceAll('{NEWLINE}', "\n" );


### PR DESCRIPTION
In addition to AUTHOR_URL, allow users to write templates like:

```
"{TWEET}" -@{AUTHOR_HANDLE}"
```

To produce output like `"I ate a cool sandwich" -@some_one` because some
Twitter users change their display name (AUTHOR_NAME) frequently making
search potentially inconsistent.